### PR TITLE
feat: link consultation button and footer socials

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -265,7 +265,7 @@ const ContactSection = () => {
             Your journey to success starts with a single step.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button variant="hero" size="lg" className="bg-white/10 border-grey/30 text-white hover:bg-white/20">
+            <Button variant="hero" size="lg" className="bg-white/10 border-grey/30 text-white hover:bg-white/20" onClick={() => navigate("/schedule-call")}>
               Start Free Consultation
             </Button>
             <Button variant="hero" size="lg" className="bg-white/10 border-grey/30 text-white hover:bg-white/20">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -78,13 +78,34 @@ const Footer = () => {
             <div className="mt-6">
               <h5 className="font-semibold mb-2">Follow Us</h5>
               <div className="flex space-x-2">
-                <a href="#" className="text-accent-foreground p-2 rounded transition-colors" aria-label="Facebook">
+                <a
+                  href="https://www.facebook.com/share/17FAqgpYkR/"
+                  className="text-accent-foreground p-2 rounded transition-colors"
+                  aria-label="Facebook"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
                     <path d="M22.675 0h-21.35C.595 0 0 .592 0 1.326v21.348C0 23.408.595 24 1.325 24h11.495v-9.294H9.692v-3.622h3.128V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.463.099 2.797.143v3.24l-1.918.001c-1.504 0-1.797.715-1.797 1.763v2.313h3.587l-.467 3.622h-3.12V24h6.116C23.406 24 24 23.408 24 22.674V1.326C24 .592 23.406 0 22.675 0" />
                   </svg>
                 </a>
-                <a href="#" className="text-accent-foreground p-2 rounded transition-colors" aria-label="Instagram">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
+                <a
+                  href="https://www.instagram.com/campuscareerconnect?utm_source=ig_web_button_share_sheet&igsh=MXQ3eGNtcGhveGZxOA=="
+                  className="text-accent-foreground p-2 rounded transition-colors"
+                  aria-label="Instagram"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="w-5 h-5"
+                  >
                     <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
                     <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
                     <line x1="17.5" y1="6.5" x2="17.5" y2="6.5" />


### PR DESCRIPTION
## Summary
- ensure the "Start Free Consultation" button navigates users to the schedule call page
- connect Facebook and Instagram footer icons to their respective social pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b96360d86083329b2a76ccb4999397

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update all instances of "Campus Career Connect" to "Campus Career Club" across various components and modify social media link targets in the footer to point to active URLs.

### Why are these changes being made?

The changes are being made to reflect the updated branding from "Campus Career Connect" to "Campus Career Club" due to a rebranding initiative. Additionally, proper social media links are added to enhance usability and engagement, connecting users directly to our active social media profiles.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a low-impact UI link change, but the introduced invalid anchor/SVG structure could break the footer layout or click targets in production.
> 
> **Overview**
> Updates the footer “Follow Us” section to point the Facebook and Instagram icons at real external URLs and open them in a new tab with `rel="noopener noreferrer"`.
> 
> Note: the current change appears to introduce **nested `<a>` tags / unbalanced SVG markup** in `Footer.tsx`, which may break rendering and should be corrected before merge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ed9241c80ce7b8239bf8ceb9550dbe90e535e3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->