### PR TITLE
Ensure hero image covers stat icons on mobile

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -10,7 +10,7 @@ const HeroSection = () => {
         <img
           src={heroStudents}
           alt="Students achieving success in their academic journey"
-          className="w-full h-full object-cover opacity-25 max-h-[60vh] sm:max-h-[70vh] md:max-h-none md:h-full md:w-full"
+          className="w-full h-full object-cover opacity-25"
           style={{ objectPosition: 'center bottom' }}
         />
       </div>


### PR DESCRIPTION
## Summary
- Remove max-height restriction from hero background image so stats overlay the photo on mobile

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1470b6194833289ef4b72d192465a